### PR TITLE
Migrated tests to py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,11 @@ before_install:
 - conda install python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS
 
 install:
-    - pip install python-coveralls
-    - pip install -e .
+    - pip install python-coveralls pytest-faulthandler
+    - pip install -e .[docs,tests]
 
 script:
-    - nosetests -v -w tests/ --with-coverage --cover-erase --cover-package=resampy
+    - py.test
 
 after_success:
     - coveralls
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov-report term-missing --cov resampy

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,16 @@ setup(
         'scipy>=0.13',
         'six>=1.3',
         'Cython>=0.21'],
+    extras_require={
+        'docs': [
+            'sphinx!=1.3.1',  # autodoc was broken in 1.3.1
+            'numpydoc',
+        ],
+        'tests': [
+            'pytest',
+            'pytest-cov',
+        ],
+    },
     classifiers=[
         "License :: OSI Approved :: ISC License (ISCL)",
         "Programming Language :: Python",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,90 +3,69 @@
 
 import numpy as np
 import scipy.signal
+import pytest
+
 import resampy
 
-from nose.tools import eq_, raises
 
-
-def test_shape():
-
-    def __test(axis, sr_orig, sr_new, X):
-
-        Y = resampy.resample(X, sr_orig, sr_new, axis=axis)
-
-        target_shape = list(X.shape)
-        target_shape[axis] = target_shape[axis] * sr_new // sr_orig
-
-        eq_(target_shape, list(Y.shape))
-
+@pytest.mark.parametrize('axis', [0, 1, 2])
+def test_shape(axis):
     sr_orig = 100
+    sr_new = sr_orig // 2
     X = np.random.randn(sr_orig, sr_orig, sr_orig)
+    Y = resampy.resample(X, sr_orig, sr_new, axis=axis)
 
-    for axis in [0, 1, 2]:
-        yield __test, axis, sr_orig, sr_orig // 2, X
+    target_shape = list(X.shape)
+    target_shape[axis] = target_shape[axis] * sr_new // sr_orig
+
+    assert target_shape == list(Y.shape)
 
 
-def test_bad_sr():
-
+@pytest.mark.xfail(raises=ValueError, strict=True)
+@pytest.mark.parametrize('sr_orig, sr_new', [(100, 0), (100, -1), (0, 100), (-1, 100)])
+def test_bad_sr(sr_orig, sr_new):
     x = np.zeros(100)
-    yield raises(ValueError)(resampy.resample), x, 100, 0
-    yield raises(ValueError)(resampy.resample), x, 100, -1
-    yield raises(ValueError)(resampy.resample), x, 0, 100
-    yield raises(ValueError)(resampy.resample), x, -1, 100
+    resampy.resample(x, sr_orig, sr_new)
 
 
-def test_bad_rolloff():
-
-    @raises(ValueError)
-    def __test(rolloff):
-
-        x = np.zeros(100)
-        resampy.resample(x, 100, 50, filter='sinc_window', rolloff=rolloff)
-    
-    yield __test, -1
-    yield __test, 1.5
+@pytest.mark.xfail(raises=ValueError, strict=True)
+@pytest.mark.parametrize('rolloff', [-1, 1.5])
+def test_bad_rolloff(rolloff):
+    x = np.zeros(100)
+    resampy.resample(x, 100, 50, filter='sinc_window', rolloff=rolloff)
 
 
-@raises(ValueError)
+@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_bad_precision():
-
     x = np.zeros(100)
     resampy.resample(x, 100, 50, filter='sinc_window', precision=-1)
-    
 
-@raises(ValueError)
+
+@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_bad_num_zeros():
-
     x = np.zeros(100)
     resampy.resample(x, 100, 50, filter='sinc_window', num_zeros=0)
 
-def test_dtype():
 
-    def __test(dtype):
-        x = np.random.randn(100).astype(dtype)
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+def test_dtype(dtype):
+    x = np.random.randn(100).astype(dtype)
+    y = resampy.resample(x, 100, 200)
 
-        y = resampy.resample(x, 100, 200)
-
-        eq_(x.dtype, y.dtype)
-
-    yield __test, np.float32
-    yield __test, np.float64
+    assert x.dtype == y.dtype
 
 
-@raises(TypeError)
+@pytest.mark.xfail(raises=TypeError)
 def test_bad_window():
-
     x = np.zeros(100)
 
     resampy.resample(x, 100, 200, filter='sinc_window', window=np.ones(50))
 
 
 def test_good_window():
-
     sr_orig = 100
     sr_new = 200
     x = np.random.randn(500)
-
     y = resampy.resample(x, sr_orig, sr_new, filter='sinc_window', window=scipy.signal.blackman)
 
-    eq_(len(y), 2 * len(x))
+    assert len(y) == 2 * len(x)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,45 +1,41 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
-import numpy as np
 import scipy
+import pytest
+
 import resampy
 
-from nose.tools import eq_, raises
 
-def test_filter_sinc():
+@pytest.mark.parametrize('filt', ['sinc_window', resampy.filters.sinc_window])
+@pytest.mark.parametrize('window', [None, scipy.signal.hann])
+@pytest.mark.parametrize('num_zeros', [None, 13])
+@pytest.mark.parametrize('precision', [None, 9])
+@pytest.mark.parametrize('rolloff', [None, 0.925])
+def test_filter_sinc(filt, window, num_zeros, precision, rolloff):
+    kwargs = dict()
+    if window is not None:
+        kwargs['window'] = window
 
-    def __test(filt, window, num_zeros, precision, rolloff):
+    if num_zeros is not None:
+        kwargs['num_zeros'] = num_zeros
 
-        kwargs = dict()
-        if window is not None:
-            kwargs['window'] = window
+    if precision is not None:
+        kwargs['precision'] = precision
 
-        if num_zeros is not None:
-            kwargs['num_zeros'] = num_zeros
+    if rolloff is not None:
+        kwargs['rolloff'] = rolloff
 
-        if precision is not None:
-            kwargs['precision'] = precision
+    interp, prec = resampy.filters.get_filter(filt, **kwargs)
 
-        if rolloff is not None:
-            kwargs['rolloff'] = rolloff
-
-        interp, prec = resampy.filters.get_filter(filt, **kwargs)
-
-        if precision in kwargs:
-            eq_(2**precision, prec)
-
-    for filt in ['sinc_window', resampy.filters.sinc_window]:
-        for window in [None, scipy.signal.hann]:
-            for num_zeros in [None, 13]:
-                for precision in [None, 9]:
-                    for rolloff in [None, 0.925]:
-                        yield __test, filt, window, num_zeros, precision, rolloff
+    if precision in kwargs:
+        assert 2**precision == prec
 
 
 def test_filter_load():
     half_win, precision = resampy.filters.get_filter('kaiser_best')
 
-@raises(NotImplementedError)
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_filter_missing():
     resampy.filters.get_filter('bad name')

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,64 +1,55 @@
 #!/usr/bin/env python
+# -*- encoding: utf-8 -*-
 
 import numpy as np
+import pytest
 
 import resampy
 
-from nose.tools import raises
 
 def make_tone(freq, sr, duration):
     return np.sin(2 * np.pi * freq / sr * np.arange(sr * duration))
 
 
 def make_sweep(freq, sr, duration):
-    
     return np.sin(np.cumsum(2 * np.pi * np.logspace(np.log2(2.0 / sr),
                                                     np.log2(float(freq) / sr),
                                                     num=duration*sr, base=2.0)))
 
-def test_quality_sine():
 
-    def __test(sr_orig, sr_new, fil, rms, x, y):
-
-        y_pred = resampy.resample(x, sr_orig, sr_new, filter=fil)
-
-        idx = slice(sr_new // 2, - sr_new//2)
-
-        err = np.mean(np.abs(y[idx] - y_pred[idx]))
-        assert err <= rms, '{:g} > {:g}'.format(err, rms)
-
+@pytest.mark.parametrize('sr_orig,sr_new', [(44100, 22050), (22050, 44100)])
+@pytest.mark.parametrize(
+    'fil,rms',
+    [('sinc_window', 1e-6), ('kaiser_fast', 1e-4), ('kaiser_best', 1e-7)]
+)
+def test_quality_sine(sr_orig, sr_new, fil, rms):
     FREQ = 512.0
     DURATION = 2.0
 
-    for (sr_orig, sr_new) in [ (44100, 22050), (22050, 44100) ]:
-        x = make_tone(FREQ, sr_orig, DURATION)
-        y = make_tone(FREQ, sr_new, DURATION)
+    x = make_tone(FREQ, sr_orig, DURATION)
+    y = make_tone(FREQ, sr_new, DURATION)
+    y_pred = resampy.resample(x, sr_orig, sr_new, filter=fil)
 
-        for (fil, rms) in [('sinc_window', 1e-6),
-                           ('kaiser_fast', 1e-4),
-                           ('kaiser_best', 1e-7)]:
-            yield __test, sr_orig, sr_new, fil, rms, x, y
+    idx = slice(sr_new // 2, - sr_new//2)
 
-def test_quality_sweep():
+    err = np.mean(np.abs(y[idx] - y_pred[idx]))
+    assert err <= rms, '{:g} > {:g}'.format(err, rms)
 
-    def __test(sr_orig, sr_new, fil, rms, x, y):
 
-        y_pred = resampy.resample(x, sr_orig, sr_new, filter=fil)
-
-        idx = slice(sr_new // 2, - sr_new//2)
-
-        err = np.mean(np.abs(y[idx] - y_pred[idx]))
-        assert err <= rms, '{:g} > {:g}'.format(err, rms)
-
+@pytest.mark.parametrize('sr_orig,sr_new', [(44100, 22050), (22050, 44100)])
+@pytest.mark.parametrize(
+    'fil,rms',
+    [('sinc_window', 1e-1), ('kaiser_fast', 1e-1), ('kaiser_best', 1e-1)]
+)
+def test_quality_sweep(sr_orig, sr_new, fil, rms):
     FREQ = 8192
     DURATION = 5.0
+    x = make_sweep(FREQ, sr_orig, DURATION)
+    y = make_sweep(FREQ, sr_new, DURATION)
 
-    for (sr_orig, sr_new) in [ (44100, 22050), (22050, 44100) ]:
-        x = make_sweep(FREQ, sr_orig, DURATION)
-        y = make_sweep(FREQ, sr_new, DURATION)
+    y_pred = resampy.resample(x, sr_orig, sr_new, filter=fil)
 
-        for (fil, rms) in [('sinc_window', 1e-1),
-                           ('kaiser_fast', 1e-1),
-                           ('kaiser_best', 1e-1)]:
-            yield __test, sr_orig, sr_new, fil, rms, x, y
+    idx = slice(sr_new // 2, - sr_new//2)
 
+    err = np.mean(np.abs(y[idx] - y_pred[idx]))
+    assert err <= rms, '{:g} > {:g}'.format(err, rms)


### PR DESCRIPTION
Nosetests has been without active development for quite a while.

Their website [recommends using Nose2, Py.test or unittests2 for new projects](http://nose.readthedocs.org/en/latest/#note-to-users), too.

Thus I have taken the liberty to migrate all unit tests over to py.test, a modern test framework with an ever growing userbase.

If you [look inside the tests](https://github.com/nils-werner/resampy/blob/pytest/tests/test_filters.py#L10) you will notice that a most of the work to test with different parameter combinations can be solved quite nicely in py.test, making most of the testsuite easier to read and maintain.