### PR TITLE
added type check for floating point inputs. Fixes #44

### DIFF
--- a/resampy/core.py
+++ b/resampy/core.py
@@ -15,8 +15,8 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
 
     Parameters
     ----------
-    x : np.ndarray
-        The input signal(s) to resample
+    x : np.ndarray, dtype=np.float*
+        The input signal(s) to resample. Must be real-valued.
 
     sr_orig : int > 0
         The sampling rate of x
@@ -44,6 +44,10 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
     ------
     ValueError
         if `sr_orig` or `sr_new` is not positive
+
+    TypeError
+        if the input signal `x` has an unsupported data type.
+        Currently, only floating point (real) types are supported.
 
     Examples
     --------
@@ -82,6 +86,10 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
 
     if sr_new <= 0:
         raise ValueError('Invalid sample rate: sr_new={}'.format(sr_new))
+
+    if not np.issubdtype(x.dtype, np.float):
+        raise TypeError('Unable to resample signals of dtype={}. '
+                        'Only floating-point types are supported.'.format(x.dtype))
 
     sample_ratio = float(sr_new) / sr_orig
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,12 +47,18 @@ def test_bad_num_zeros():
     resampy.resample(x, 100, 50, filter='sinc_window', num_zeros=0)
 
 
-@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64,
+                                   np.int16, np.int32, np.int64])
 def test_dtype(dtype):
     x = np.random.randn(100).astype(dtype)
-    y = resampy.resample(x, 100, 200)
 
-    assert x.dtype == y.dtype
+    if np.issubdtype(dtype, np.float):
+        y = resampy.resample(x, 100, 200)
+
+        assert x.dtype == y.dtype
+    else:
+        with pytest.raises(TypeError):
+            y = resampy.resample(x, 100, 200)
 
 
 @pytest.mark.xfail(raises=TypeError)


### PR DESCRIPTION
This fixes #44 by requiring input signals to have dtype of `np.float` (or one of its subclasses).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/resampy/45)
<!-- Reviewable:end -->
