### PR TITLE
mocking numba in doc build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ project = u'resampy'
 copyright = u'2016, Brian McFee'
 
 import mock
-MOCK_MODULES = ['numpy', 'scipy', 'scipy.signal', 'resampy.interp']
+MOCK_MODULES = ['numpy', 'scipy', 'scipy.signal', 'resampy.interp', 'numba']
 sys.modules.update((mod_name, mock.Mock()) for mod_name in MOCK_MODULES)
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This should fix #65 by adding numba to the mock list in the documentation build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/resampy/66)
<!-- Reviewable:end -->
