### PR TITLE
Preserve contiguity in resampling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 env:
   global:
     # Directory where tests are run from
-    - CONDA_DEPS="pip nose numpy scipy numba"
+    - CONDA_DEPS="pip nose numpy scipy numba pytest<4 coveralls"
 
 before_install:
 - export MINICONDA=$HOME/miniconda
@@ -35,7 +35,6 @@ before_install:
 - conda install python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS
 
 install:
-    - pip install python-coveralls pytest-faulthandler
     - pip install -e .[docs,tests]
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ notifications:
 
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
 
 cache:
     directories:
@@ -39,7 +39,7 @@ install:
     - pip install -e .[docs,tests]
 
 script:
-    - py.test
+    - pytest
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 - conda update conda
 - conda info -a
 - conda install python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS
+- conda install -c conda-forge pytest-faulthandler
 
 install:
     - pip install -e .[docs,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 - conda update conda
 - conda info -a
 - conda install python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS
-- conda install -c conda-forge pytest-faulthandler
 
 install:
     - pip install -e .[docs,tests]

--- a/resampy/core.py
+++ b/resampy/core.py
@@ -97,7 +97,14 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
         raise ValueError('Input signal length={} is too small to '
                          'resample from {}->{}'.format(x.shape[axis], sr_orig, sr_new))
 
-    y = np.zeros(shape, dtype=x.dtype)
+    # Preserve contiguity of input (if it exists)
+    # If not, revert to C-contiguity by default
+    if x.flags['F_CONTIGUOUS']:
+        order = 'F'
+    else:
+        order = 'C'
+
+    y = np.zeros(shape, dtype=x.dtype, order=order)
 
     interp_win, precision, _ = get_filter(filter, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
             'numpydoc',
         ],
         'tests': [
-            'pytest',
+            'pytest < 4',
             'pytest-cov',
         ],
     },
@@ -42,8 +42,8 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -78,3 +78,17 @@ def test_good_window():
     y = resampy.resample(x, sr_orig, sr_new, filter='sinc_window', window=scipy.signal.blackman)
 
     assert len(y) == 2 * len(x)
+
+
+@pytest.mark.parametrize('order', ['C', 'F'])
+@pytest.mark.parametrize('shape', [(50,), (10, 50), (10, 25, 50)])
+@pytest.mark.parametrize('axis', [0, -1])
+def test_contiguity(order, shape, axis):
+
+    x = np.zeros(shape, dtype=np.float, order=order)
+    sr_orig = 1
+    sr_new = 2
+    y = resampy.resample(x, sr_orig, sr_new, axis=axis)
+
+    assert x.flags['C_CONTIGUOUS'] == y.flags['C_CONTIGUOUS']
+    assert x.flags['F_CONTIGUOUS'] == y.flags['F_CONTIGUOUS']

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -8,13 +8,13 @@ import resampy
 
 
 def make_tone(freq, sr, duration):
-    return np.sin(2 * np.pi * freq / sr * np.arange(sr * duration))
+    return np.sin(2 * np.pi * freq / sr * np.arange(int(sr * duration)))
 
 
 def make_sweep(freq, sr, duration):
     return np.sin(np.cumsum(2 * np.pi * np.logspace(np.log2(2.0 / sr),
                                                     np.log2(float(freq) / sr),
-                                                    num=duration*sr, base=2.0)))
+                                                    num=int(duration*sr), base=2.0)))
 
 
 @pytest.mark.parametrize('sr_orig,sr_new', [(44100, 22050), (22050, 44100)])


### PR DESCRIPTION
This PR fixes #68 by propagating array contiguity from the input buffer.

If the input is neither F nor C contiguous, the output reverts to C-contiguity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/resampy/69)
<!-- Reviewable:end -->
