### PR TITLE
Enable CI testing with GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: windows-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.10"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Conda Environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        python-version: ${{ matrix.python-version }}
+        use-mamba: true
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        mamba install typing_extensions!=4.2
+        mamba install pip numpy scipy numba pytest
+    - name: Install
+      shell: bash -l {0}
+      run: |
+        python -m pip install -e .[docs,tests]
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install
       shell: bash -l {0}
       run: |
-        python -m pip install -e .[docs,tests]
+        python -m pip install -e .[tests]
     - name: Test
       shell: bash -l {0}
       run: |

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
             'numpydoc',
         ],
         'tests': [
-            'pytest < 4',
+            'pytest < 8',
             'pytest-cov',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
* Enable Continuous Integration (CI) testing with GitHub Action (GHA)
* update min pytest version for compatibility with Python 3.10
* Update classifier to declare support for Python 3.8, 3.9 and 3.10