### PR TITLE
Fixed #76 - matched input and output rates

### DIFF
--- a/resampy/core.py
+++ b/resampy/core.py
@@ -27,6 +27,9 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
     sr_new : int > 0
         The target sampling rate of the output signal(s)
 
+        If `sr_new == sr_orig`, then a copy of `x` is returned with no
+        interpolation performed.
+
     axis : int
         The target axis along which to resample `x`
 
@@ -90,6 +93,10 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
 
     if sr_new <= 0:
         raise ValueError('Invalid sample rate: sr_new={}'.format(sr_new))
+
+    if sr_orig == sr_new:
+        # If the output rate matches, return a copy
+        return x.copy()
 
     sample_ratio = float(sr_new) / sr_orig
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -158,6 +158,6 @@ def test_resample_matched():
     # All values should match
     assert np.allclose(x, y)
     # y should own the data
-    assert y.FLAGS['owndata']
+    assert y.flags['OWNDATA']
     # x and y are distinct objects
     assert y is not x

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,3 +149,15 @@ def test_resample_nu_domain(shape, axis, domain):
     x = np.zeros(shape, dtype=np.float64)
     t = np.linspace(*domain, num=10, endpoint=True)
     resampy.resample_nu(x, 1., t, axis=axis)
+
+
+def test_resample_matched():
+    x = np.random.randn(100)
+    y = resampy.resample(x, 1, 1)
+
+    # All values should match
+    assert np.allclose(x, y)
+    # y should own the data
+    assert y.FLAGS['owndata']
+    # x and y are distinct objects
+    assert y is not x


### PR DESCRIPTION
Fixes #76 

If input and output rates are identical, then a copy of the input signal is returned with no interpolation.

This prevents ringing artifacts at the signal boundary, and is consistent with scipy resampling behavior in this situation.

