### PR TITLE
dropped legacy python support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
           - os: windows-latest
             python-version: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
           - os: windows-latest
             python-version: "3.10"

--- a/resampy/core.py
+++ b/resampy/core.py
@@ -2,8 +2,6 @@
 # -*- encoding: utf-8 -*-
 '''Core resampling interface'''
 
-from __future__ import division
-
 import numpy as np
 
 from .filters import get_filter

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -33,7 +33,6 @@ import scipy.signal
 import numpy as np
 import os
 import pkg_resources
-import six
 import sys
 
 FILTER_FUNCTIONS = ['sinc_window']
@@ -95,7 +94,7 @@ def sinc_window(num_zeros=64, precision=9, window=None, rolloff=0.945):
 
     if window is None:
         window = scipy.signal.blackmanharris
-    elif not six.callable(window):
+    elif not callable(window):
         raise TypeError('window must be callable, not type(window)={}'.format(type(window)))
 
     if not 0 < rolloff <= 1:
@@ -158,7 +157,7 @@ def get_filter(name_or_function, **kwargs):
     '''
     if name_or_function in FILTER_FUNCTIONS:
         return getattr(sys.modules[__name__], name_or_function)(**kwargs)
-    elif six.callable(name_or_function):
+    elif callable(name_or_function):
         return name_or_function(**kwargs)
     else:
         try:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ setup(
     install_requires=[
         'numpy>=1.10',
         'scipy>=0.13',
-        'numba>=0.32',
-        'six>=1.3'],
+        'numba>=0.32'],
     extras_require={
         'docs': [
             'sphinx!=1.3.1',  # autodoc was broken in 1.3.1
@@ -39,8 +38,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Fixes #86 - our minimum python version is now 3.6.