### PR TITLE
Fixing high-dimensional resampling

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -34,7 +34,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install typing_extensions!=4.2 pytest
-        mamba install pip numpy==1.17 scipy==0.13 numba==0.32
+        mamba install pip numpy==1.17 scipy==1.0 numba==0.41
 
     - name: Install
       shell: bash -l {0}

--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: CI
+name: CI-minimal
 
 on:
   push:
@@ -19,12 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        include:
-          - os: windows-latest
-            python-version: "3.10"
-          - os: macos-latest
-            python-version: "3.10"
+        python-version: ["3.6"]
 
     steps:
     - uses: actions/checkout@v2
@@ -38,8 +33,9 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        mamba install typing_extensions!=4.2
-        mamba install pip numpy scipy numba pytest pytest-cov pytest-doctestplus
+        mamba install typing_extensions!=4.2 pytest
+        mamba install pip numpy==1.17 scipy==0.13 numba==0.32
+
     - name: Install
       shell: bash -l {0}
       run: |
@@ -48,14 +44,3 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m pytest
-        python -m pytest --doctest-only
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        files: ./coverage.xml
-        directory: ./coverage/reports/
-        flags: unittests
-        env_vars: OS,PYTHON
-        name: codecov-umbrella
-        fail_ci_if_error: true
-        verbose: true

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -72,6 +72,7 @@ def sinc_window(num_zeros=64, precision=9, window=None, rolloff=0.945):
 
     Examples
     --------
+    >>> import scipy
     >>> import resampy
     >>> np.set_printoptions(threshold=5, suppress=False)
     >>> # A filter with 10 zero-crossings, 32 samples per crossing, and a

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -29,7 +29,6 @@ where ``**kwargs`` are additional parameters to `resampy.filters.sinc_window`_.
 
 '''
 
-import scipy.signal
 import numpy as np
 import os
 import pkg_resources
@@ -50,7 +49,7 @@ def sinc_window(num_zeros=64, precision=9, window=None, rolloff=0.945):
     precision : int > 0
         The number of filter coefficients to retain for each zero-crossing
     window : callable
-        The window function.  By default, uses Blackman-Harris.
+        The window function.  By default, uses a Hann window.
     rolloff : float > 0
         The roll-off frequency (as a fraction of nyquist)
 
@@ -93,7 +92,7 @@ def sinc_window(num_zeros=64, precision=9, window=None, rolloff=0.945):
     '''
 
     if window is None:
-        window = scipy.signal.blackmanharris
+        window = np.hanning
     elif not callable(window):
         raise TypeError('window must be callable, not type(window)={}'.format(type(window)))
 

--- a/resampy/interpn.py
+++ b/resampy/interpn.py
@@ -19,7 +19,6 @@ def resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
 
     nwin = interp_win.shape[0]
     n_orig = x.shape[0]
-    n_channels = y.shape[1]
     n_out = t_out.shape[0]
 
     for t in numba.prange(n_out):
@@ -43,8 +42,7 @@ def resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
         for i in range(i_max):
 
             weight = (interp_win[offset + i * index_step] + eta * interp_delta[offset + i * index_step])
-            for j in range(n_channels):
-                y[t, j] += weight * x[n - i, j]
+            y[t] += weight * x[n-i]
 
         # Invert P
         frac = scale - frac
@@ -60,5 +58,4 @@ def resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
         k_max = min(n_orig - n - 1, (nwin - offset) // index_step)
         for k in range(k_max):
             weight = (interp_win[offset + k * index_step] + eta * interp_delta[offset + k * index_step])
-            for j in range(n_channels):
-                y[t, j] += weight * x[n + k + 1, j]
+            y[t] += weight * x[n + k + 1]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=['resampy'],
     package_data={'resampy': ['data/*']},
     install_requires=[
-        'numpy>=1.10',
+        'numpy>=1.17',
         'scipy>=0.13',
         'numba>=0.32'],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setup(
     package_data={'resampy': ['data/*']},
     install_requires=[
         'numpy>=1.17',
-        'scipy>=0.13',
-        'numba>=0.32'],
+        'numba>=0.41'],
     extras_require={
         'docs': [
             'sphinx!=1.3.1',  # autodoc was broken in 1.3.1
@@ -30,6 +29,7 @@ setup(
         'tests': [
             'pytest < 8',
             'pytest-cov',
+            'scipy>=1.0',
         ],
     },
     classifiers=[

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -161,3 +161,16 @@ def test_resample_matched():
     assert y.flags['OWNDATA']
     # x and y are distinct objects
     assert y is not x
+
+
+def test_resample_axis():
+    # derived from https://github.com/bmcfee/resampy/issues/73
+
+    rand_arr = np.abs(np.random.rand(3, 4, 5, 100))
+
+    resampled_arr = resampy.resample(rand_arr, 100, 24, axis=3)
+
+    resampled_t_arr = resampy.resample(np.transpose(rand_arr), 100, 24, axis=0)
+
+    assert np.allclose(resampled_arr, np.transpose(resampled_t_arr))
+    assert (resampled_arr**2).sum() > 0


### PR DESCRIPTION
This PR should resolve #73 , and provides a few other simplifications and cleanups within the code algorithm.

It bumps the minimal numpy to 1.17 (for improved zeros_like behavior) and numba to 0.41 (mainly due to availability on conda-forge).

It also adds a minimal CI environment for our oldest dependency versions.  In setting this up, I realized that we don't really need scipy at runtime, so I've made it a test-only dependency.  This isn't a huge change (default filter is now Hann instead of Blackman-Harris; the default is not used by the user-facing API though), and I expect that anyone using resampy will have scipy anyway.  The reason to drop it as a dependency is that it simplifies our minimal version spec.