### PR TITLE
Enable parallelism

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -34,7 +34,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install typing_extensions!=4.2 pytest
-        mamba install pip numpy==1.17 scipy==1.0 numba==0.41
+        mamba install pip numpy==1.17 scipy==1.0 numba==0.47
 
     - name: Install
       shell: bash -l {0}

--- a/resampy/core.py
+++ b/resampy/core.py
@@ -6,12 +6,12 @@ import numpy as np
 
 from .filters import get_filter
 
-from .interpn import resample_f
+from .interpn import resample_f_s, resample_f_p
 
 __all__ = ['resample', 'resample_nu']
 
 
-def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
+def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', parallel=True, **kwargs):
     '''Resample a signal x from sr_orig to sr_new along a given axis.
 
     Parameters
@@ -35,6 +35,11 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
         The resampling filter to use.
 
         By default, uses the `kaiser_best` (pre-computed filter).
+    
+    parallel : optional, bool
+        Enable/disable parallel computation exploiting multi-threading.
+
+        Default: True.
 
     **kwargs
         additional keyword arguments provided to the specified filter
@@ -121,13 +126,17 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', **kwargs):
     time_increment = 1. / sample_ratio
     t_out = np.arange(shape[axis]) * time_increment
 
-    resample_f(x.swapaxes(0, axis), y.swapaxes(0, axis),
-               t_out, interp_win, interp_delta, precision, scale)
+    if parallel:
+        resample_f_p(x.swapaxes(0, axis), y.swapaxes(0, axis),
+                     t_out, interp_win, interp_delta, precision, scale)
+    else:
+        resample_f_s(x.swapaxes(0, axis), y.swapaxes(0, axis),
+                     t_out, interp_win, interp_delta, precision, scale)
 
     return y
 
 
-def resample_nu(x, sr_orig, t_out, axis=-1, filter='kaiser_best', **kwargs):
+def resample_nu(x, sr_orig, t_out, axis=-1, filter='kaiser_best', parallel=True, **kwargs):
     '''Interpolate a signal x at specified positions (t_out) along a given axis.
 
     Parameters
@@ -148,6 +157,11 @@ def resample_nu(x, sr_orig, t_out, axis=-1, filter='kaiser_best', **kwargs):
         The resampling filter to use.
 
         By default, uses the `kaiser_best` (pre-computed filter).
+
+    parallel : optional, bool
+        Enable/disable parallel computation exploiting multi-threading.
+
+        Default: True.
 
     **kwargs
         additional keyword arguments provided to the specified filter
@@ -215,6 +229,9 @@ def resample_nu(x, sr_orig, t_out, axis=-1, filter='kaiser_best', **kwargs):
     if sr_orig != 1.:
         t_out = t_out * sr_orig
 
-    resample_f(x.swapaxes(0, axis), y.swapaxes(0, axis), t_out, interp_win, interp_delta, precision)
+    if parallel:
+        resample_f_p(x.swapaxes(0, axis), y.swapaxes(0, axis), t_out, interp_win, interp_delta, precision)
+    else:
+        resample_f_s(x.swapaxes(0, axis), y.swapaxes(0, axis), t_out, interp_win, interp_delta, precision)
 
     return y

--- a/resampy/core.py
+++ b/resampy/core.py
@@ -35,7 +35,7 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', parallel=True, *
         The resampling filter to use.
 
         By default, uses the `kaiser_best` (pre-computed filter).
-    
+
     parallel : optional, bool
         Enable/disable parallel computation exploiting multi-threading.
 

--- a/resampy/interpn.py
+++ b/resampy/interpn.py
@@ -1,18 +1,10 @@
 #!/usr/bin/env python
 '''Numba implementation of resampler'''
 
-import os
 import numba
 
 
-if os.environ.get('RESAMPY_PARALLEL', '').lower() in {'0', 'off', 'false', 'no'}:
-    _ENABLE_JIT_PARALLEL = False
-else:
-    _ENABLE_JIT_PARALLEL = True
-
-
-@numba.jit(nopython=True, nogil=True, parallel=_ENABLE_JIT_PARALLEL)
-def resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
+def _resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
 
     index_step = int(scale * num_table)
     time_register = 0.0
@@ -66,3 +58,6 @@ def resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
         for k in range(k_max):
             weight = (interp_win[offset + k * index_step] + eta * interp_delta[offset + k * index_step])
             y[t] += weight * x[n + k + 1]
+
+resample_f_p = numba.jit(nopython=True, nogil=True, parallel=True, cache=True)(_resample_f)
+resample_f_s = numba.jit(nopython=True, nogil=True, parallel=False, cache=True)(_resample_f)

--- a/resampy/interpn.py
+++ b/resampy/interpn.py
@@ -59,5 +59,5 @@ def _resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
             weight = (interp_win[offset + k * index_step] + eta * interp_delta[offset + k * index_step])
             y[t] += weight * x[n + k + 1]
 
-resample_f_p = numba.jit(nopython=True, nogil=True, parallel=True, cache=True)(_resample_f)
-resample_f_s = numba.jit(nopython=True, nogil=True, parallel=False, cache=True)(_resample_f)
+resample_f_p = numba.jit(nopython=True, nogil=True, parallel=True)(_resample_f)
+resample_f_s = numba.jit(nopython=True, nogil=True, parallel=False)(_resample_f)

--- a/resampy/interpn.py
+++ b/resampy/interpn.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python
 '''Numba implementation of resampler'''
 
+import os
 import numba
 
 
-@numba.jit(nopython=True, nogil=True)
+if os.environ.get('RESAMPY_PARALLEL', '').lower() in {'0', 'off', 'false', 'no'}:
+    _ENABLE_JIT_PARALLEL = False
+else:
+    _ENABLE_JIT_PARALLEL = True
+
+
+@numba.jit(nopython=True, nogil=True, parallel=_ENABLE_JIT_PARALLEL)
 def resample_f(x, y, t_out, interp_win, interp_delta, num_table, scale=1.0):
 
     index_step = int(scale * num_table)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_package_data = True
 python_requires >= 3.6
 install_requires =
     numpy>=1.17
-    numba>=0.41
+    numba>=0.47
 
 [options.package_data]
 resampy = data/*

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -103,14 +103,13 @@ def test_quality_sine_parallel(sr_orig, sr_new):
     FREQ = 512.0
     DURATION = 2.0
     FILTER = 'sinc_window'
-    RMS = 1e-13
+    RTOL = 1e-13
 
     x, _ = make_tone(FREQ, sr_orig, DURATION)
     y_seq = resampy.resample(x, sr_orig, sr_new, filter=FILTER, parallel=False)
     y_par = resampy.resample(x, sr_orig, sr_new, filter=FILTER, parallel=True)
 
-    err = np.sqrt(np.mean(np.abs(y_seq - y_par)**2))
-    assert err <= RMS, '{:g} > {:g}'.format(err, RMS)
+    np.testing.assert_allclose(y_seq, y_par, rtol=RTOL)
  
 
 @pytest.mark.parametrize('sr_orig,sr_new', [(44100, 22050), (22050, 44100)])
@@ -118,7 +117,7 @@ def test_resample_nu_quality_sine_parallel(sr_orig, sr_new):
     FREQ = 512.0
     DURATION = 2.0
     FILTER = 'sinc_window'
-    RMS = 1e-13
+    RTOL = 1e-13
 
     x, _ = make_tone(FREQ, sr_orig, DURATION)
     _, t_out = make_tone(FREQ, sr_new, DURATION)
@@ -126,5 +125,4 @@ def test_resample_nu_quality_sine_parallel(sr_orig, sr_new):
     y_seq = resampy.resample_nu(x, sr_orig, t_out[:-1], filter=FILTER, parallel=False)
     y_par = resampy.resample_nu(x, sr_orig, t_out[:-1], filter=FILTER, parallel=True)
 
-    err = np.sqrt(np.mean(np.abs(y_seq - y_par)**2))
-    assert err <= RMS, '{:g} > {:g}'.format(err, RMS)
+    np.testing.assert_allclose(y_seq, y_par, rtol=RTOL)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -96,3 +96,35 @@ def test_resample_nu_quality_sweep(sr_orig, sr_new, fil, rms):
 
     err = np.mean(np.abs(y[:-1][idx] - y_pred[idx]))
     assert err <= rms, '{:g} > {:g}'.format(err, rms)
+
+
+@pytest.mark.parametrize('sr_orig,sr_new', [(44100, 22050), (22050, 44100)])
+def test_quality_sine_parallel(sr_orig, sr_new):
+    FREQ = 512.0
+    DURATION = 2.0
+    FILTER = 'sinc_window'
+    RMS = 1e-13
+
+    x, _ = make_tone(FREQ, sr_orig, DURATION)
+    y_seq = resampy.resample(x, sr_orig, sr_new, filter=FILTER, parallel=False)
+    y_par = resampy.resample(x, sr_orig, sr_new, filter=FILTER, parallel=True)
+
+    err = np.sqrt(np.mean(np.abs(y_seq - y_par)**2))
+    assert err <= RMS, '{:g} > {:g}'.format(err, RMS)
+ 
+
+@pytest.mark.parametrize('sr_orig,sr_new', [(44100, 22050), (22050, 44100)])
+def test_resample_nu_quality_sine_parallel(sr_orig, sr_new):
+    FREQ = 512.0
+    DURATION = 2.0
+    FILTER = 'sinc_window'
+    RMS = 1e-13
+
+    x, _ = make_tone(FREQ, sr_orig, DURATION)
+    _, t_out = make_tone(FREQ, sr_new, DURATION)
+
+    y_seq = resampy.resample_nu(x, sr_orig, t_out[:-1], filter=FILTER, parallel=False)
+    y_par = resampy.resample_nu(x, sr_orig, t_out[:-1], filter=FILTER, parallel=True)
+
+    err = np.sqrt(np.mean(np.abs(y_seq - y_par)**2))
+    assert err <= RMS, '{:g} > {:g}'.format(err, RMS)


### PR DESCRIPTION
This PR enable the numba jit parallel option by default.
The option can be disabled by setting an environment variable. 