### PR TITLE
Filter cache

### DIFF
--- a/resampy/core.py
+++ b/resampy/core.py
@@ -117,7 +117,8 @@ def resample(x, sr_orig, sr_new, axis=-1, filter='kaiser_best', parallel=True, *
     interp_win, precision, _ = get_filter(filter, **kwargs)
 
     if sample_ratio < 1:
-        interp_win *= sample_ratio
+        # Make a copy to prevent modifying the filters in place
+        interp_win = sample_ratio * interp_win
 
     interp_delta = np.zeros_like(interp_win)
     interp_delta[:-1] = np.diff(interp_win)

--- a/resampy/core.py
+++ b/resampy/core.py
@@ -206,7 +206,7 @@ def resample_nu(x, sr_orig, t_out, axis=-1, filter='kaiser_best', parallel=True,
 
     t_out = np.asarray(t_out)
     if t_out.ndim != 1:
-        raise ValueError('Invalide t_out shape ({}), 1D array expected'.format(t_out.shape))
+        raise ValueError('Invalid t_out shape ({}), 1D array expected'.format(t_out.shape))
     if np.min(t_out) < 0 or np.max(t_out) > (x.shape[axis] - 1) / sr_orig:
         raise ValueError('Output domain [{}, {}] exceeds the data domain [0, {}]'.format(
             np.min(t_out), np.max(t_out), (x.shape[axis] - 1) / sr_orig))

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -187,7 +187,6 @@ def get_filter(name_or_function, **kwargs):
 def load_filter(filter_name):
     '''Retrieve a pre-computed filter.
 
-    
     Parameters
     ----------
     filter_name : str

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -51,8 +51,9 @@ import pkg_resources
 import sys
 
 FILTER_FUNCTIONS = ['sinc_window']
+FILTER_CACHE = dict()
 
-__all__ = ['get_filter'] + FILTER_FUNCTIONS
+__all__ = ['get_filter', 'clear_cache'] + FILTER_FUNCTIONS
 
 
 def sinc_window(num_zeros=64, precision=9, window=None, rolloff=0.945):
@@ -186,6 +187,7 @@ def get_filter(name_or_function, **kwargs):
 def load_filter(filter_name):
     '''Retrieve a pre-computed filter.
 
+    
     Parameters
     ----------
     filter_name : str
@@ -201,9 +203,21 @@ def load_filter(filter_name):
         The roll-off frequency of the filter, as a fraction of Nyquist
     '''
 
-    fname = os.path.join('data',
-                         os.path.extsep.join([filter_name, 'npz']))
+    if filter_name not in FILTER_CACHE:
+        fname = os.path.join('data',
+                             os.path.extsep.join([filter_name, 'npz']))
 
-    data = np.load(pkg_resources.resource_filename(__name__, fname))
+        data = np.load(pkg_resources.resource_filename(__name__, fname))
+        FILTER_CACHE[filter_name] = data['half_window'], data['precision'], data['rolloff']
 
-    return data['half_window'], data['precision'], data['rolloff']
+    return FILTER_CACHE[filter_name]
+
+
+def clear_cache():
+    '''Clear the filter cache.
+
+    Calling this function will ensure that packaged filters are reloaded
+    upon the next usage.
+    '''
+
+    FILTER_CACHE.clear()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,6 +43,21 @@ def test_bad_sr(sr_orig, sr_new):
 
 
 @pytest.mark.xfail(raises=ValueError, strict=True)
+@pytest.mark.parametrize('sr', [0, -1])
+def test_bad_sr_nu(sr):
+    x = np.zeros(100)
+    t = np.arange(3)
+    resampy.resample_nu(x, sr, t)
+
+
+@pytest.mark.xfail(raises=ValueError, strict=True)
+@pytest.mark.parametrize('t', [np.empty(0), np.eye(3)])
+def test_bad_time_nu(t):
+    x = np.zeros(100)
+    resampy.resample_nu(x, 1, t)
+
+
+@pytest.mark.xfail(raises=ValueError, strict=True)
 @pytest.mark.parametrize('rolloff', [-1, 1.5])
 def test_bad_rolloff(rolloff):
     x = np.zeros(100)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
+import numpy as np
 import scipy
 import pytest
 
@@ -39,3 +40,19 @@ def test_filter_load():
 @pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_filter_missing():
     resampy.filters.get_filter('bad name')
+
+
+@pytest.mark.parametrize('sr1, sr2', [(1, 2), (2, 1)])
+def test_filter_cache_reset(sr1, sr2):
+    x = np.random.randn(100)
+    y1 = resampy.resample(x, sr1, sr2, filter='kaiser_fast')
+
+    assert len(resampy.filters.FILTER_CACHE) > 0
+
+    resampy.filters.clear_cache()
+
+    assert len(resampy.filters.FILTER_CACHE) == 0
+
+    y2 = resampy.resample(x, sr1, sr2, filter='kaiser_fast')
+
+    assert np.allclose(y1, y2)


### PR DESCRIPTION
This PR fixes #97 and adds functionality to reset the cache.  (This should never be necessary, but it can be helpful for debugging.)

In implementing this, I had to rewrite an in-place multiply of the filter coefficients 
https://github.com/bmcfee/resampy/blob/56415951d25a539a6fb6f0065dfcf1379f6a3c8a/resampy/core.py#L117-L120
with a copy-multiply.  This will cost us a little when downsampling, but is free for upsampling.  I don't think the cost is any more than what we were already paying for redundant loading from disk each time, so it should be a net win.  In my informal benchmarks, I'm seeing improvements on the order of 10ms.

I've put in a few more tests to bring up the coverage while I'm at it.  In doing so, I found what I think to be a dead code path introduced in #82 , and I'd like @avalentino to confirm:

https://github.com/bmcfee/resampy/blob/56415951d25a539a6fb6f0065dfcf1379f6a3c8a/resampy/core.py#L206-L219

Failing on this last check would require `len(t_out) < 1` (i.e., `len(t_out) == 0`), but this would fail earlier when trying to compute the min and max in the second check.  (Numpy min or max of an empty array triggers a ValueError.)  On the surface, we can safely remove this check, but I'm wondering if it's a bug and is intended to be checking something other than the domain check?

