### PR TITLE
Fix length calculation error

### DIFF
--- a/resampy/core.py
+++ b/resampy/core.py
@@ -107,7 +107,9 @@ def resample(
 
     # Set up the output shape
     shape = list(x.shape)
-    shape[axis] = int(shape[axis] * sample_ratio)
+    # Explicitly recalculate length here instead of using sample_ratio
+    # This avoids a floating point round-off error identified as #111
+    shape[axis] = int(shape[axis] * sr_new / sr_orig)
 
     if shape[axis] < 1:
         raise ValueError(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -207,3 +207,10 @@ def test_resample_axis():
 
     assert np.allclose(resampled_arr, np.transpose(resampled_t_arr))
     assert (resampled_arr**2).sum() > 0
+
+
+def test_resample_length_rounding():
+    # Test for length calculation edge case https://github.com/bmcfee/resampy/issues/111
+    x = np.zeros(12499)
+    y = resampy.resample(x, 12499, 15001)
+    assert len(y) == 15001


### PR DESCRIPTION
Fixes #111 

This PR fixes an edge case in the length calculation of output buffers by changing the order of operations in the multiplication and division.

A new test is added to cover the triggering case.
