### PR TITLE
force floating point math for shape calculations

### DIFF
--- a/resampy/core.py
+++ b/resampy/core.py
@@ -111,7 +111,7 @@ def resample(
     shape = list(x.shape)
     # Explicitly recalculate length here instead of using sample_ratio
     # This avoids a floating point round-off error identified as #111
-    shape[axis] = int(shape[axis] * sr_new / sr_orig)
+    shape[axis] = int(shape[axis] * float(sr_new) / float(sr_orig))
 
     if shape[axis] < 1:
         raise ValueError(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -214,3 +214,13 @@ def test_resample_length_rounding():
     x = np.zeros(12499)
     y = resampy.resample(x, 12499, 15001)
     assert len(y) == 15001
+
+
+def test_resample_rates_fixedprecision():
+    # Test for avoiding ill effects of fixed-precision math
+    # This should fix a bug in librosa https://github.com/librosa/librosa/issues/1569
+
+    x = np.zeros(720200)
+    sr_out = np.int32(4000)
+    sr_in = 22050
+    resampy.resample(x, sr_in, sr_out)


### PR DESCRIPTION
This PR force-casts sampling rates to be floating point values when calculating the output shape of the resampled array.

This is designed to circumvent numerical overflows that arise when `sr_new` is a fixed-precision integer (eg `np.int16`) for some reason.  This didn't arise in our tests here, but did pop up over in https://github.com/librosa/librosa/issues/1569