### PR TITLE
Fix error in documentation of resample function

### DIFF
--- a/resampy/core.py
+++ b/resampy/core.py
@@ -43,7 +43,7 @@ def resample(
     parallel : optional, bool
         Enable/disable parallel computation exploiting multi-threading.
 
-        Default: True.
+        Default: False.
 
     **kwargs
         additional keyword arguments provided to the specified filter


### PR DESCRIPTION
Fix error stating default value of parameter "parallel" in resample function