### PR TITLE
filters: use importlib_resources API to avoid deprecation warning

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -34,7 +34,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install typing_extensions!=4.2 pytest
-        mamba install pip numpy==1.17 scipy==1.0 numba==0.53
+        mamba install pip numpy==1.17 scipy==1.0 numba==0.53 importlib_resources
 
     - name: Install
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install typing_extensions!=4.2
-        mamba install pip numpy scipy numba pytest pytest-cov pytest-doctestplus
+        mamba install pip numpy scipy numba pytest pytest-cov pytest-doctestplus importlib_resources
     - name: Install
       shell: bash -l {0}
       run: |

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -46,8 +46,7 @@ where ``**kwargs`` are additional parameters to `sinc_window`.
 '''
 
 import numpy as np
-import os
-import pkg_resources
+import importlib_resources
 import sys
 
 FILTER_FUNCTIONS = ['sinc_window']
@@ -203,10 +202,10 @@ def load_filter(filter_name):
     '''
 
     if filter_name not in FILTER_CACHE:
-        fname = os.path.join('data',
-                             os.path.extsep.join([filter_name, 'npz']))
+        fname = importlib_resources.files(__name__) / 'data' / f'{filter_name}.npz'
+        with importlib_resources.as_file(fname) as f:
+            data = np.load(f)
 
-        data = np.load(pkg_resources.resource_filename(__name__, fname))
         FILTER_CACHE[filter_name] = data['half_window'], data['precision'], data['rolloff']
 
     return FILTER_CACHE[filter_name]

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -202,7 +202,7 @@ def load_filter(filter_name):
     '''
 
     if filter_name not in FILTER_CACHE:
-        fname = importlib_resources.files(__name__) / 'data' / f'{filter_name}.npz'
+        fname = importlib_resources.files("resampy") / 'data' / f'{filter_name}.npz'
         with importlib_resources.as_file(fname) as f:
             data = np.load(f)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ python_requires >= 3.6
 install_requires =
     numpy>=1.17
     numba>=0.53
+    importlib_resources
 
 [options.package_data]
 resampy = data/*


### PR DESCRIPTION
Fix deprecation warning "pkg_resources is deprecated as an API"