### PR TITLE
Minor updates to tests and packaging

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -34,7 +34,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install typing_extensions!=4.2 pytest
-        mamba install pip numpy==1.17 scipy==1.0 numba==0.53 importlib_resources
+        mamba install pip numpy==1.17 scipy==1.0 numba==0.53
 
     - name: Install
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.12"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.12"
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install typing_extensions!=4.2
-        mamba install pip numpy scipy numba pytest pytest-cov pytest-doctestplus importlib_resources
+        mamba install pip numpy scipy numba pytest pytest-cov pytest-doctestplus
     - name: Install
       shell: bash -l {0}
       run: |
@@ -50,8 +50,9 @@ jobs:
         python -m pytest tests
         python -m pytest --doctest-only resampy
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         directory: ./coverage/reports/
         flags: unittests

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changes
 -------
 
+v0.4.3
+~~~~~~
+2024-03-05
+
+- `#117 <https://github.com/bmcree/resampy/pull/117>`_ Update to remove deprecated usage of pkg_resources.
+
 v0.4.2
 ~~~~~~
 2022-09-13

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -50,8 +50,9 @@ import sys
 
 try:
     # Try to import from the standard library first (Python >= 3.9)
+if sys.version_info < (3, 9)
     from importlib import resources as importlib_resources
-except ImportError:
+else:
     # Fall back to the backport
     import importlib_resources
 

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -48,12 +48,11 @@ where ``**kwargs`` are additional parameters to `sinc_window`.
 import numpy as np
 import sys
 
-# Try to import from the standard library first (Python >= 3.9)
 if sys.version_info < (3, 9):
-    from importlib import resources as importlib_resources
-else:
-    # Fall back to the backport
+    # Use the backport of importlib resources for old python
     import importlib_resources
+else:
+    from importlib import resources as importlib_resources
 
 
 FILTER_FUNCTIONS = ['sinc_window']

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -48,8 +48,7 @@ where ``**kwargs`` are additional parameters to `sinc_window`.
 import numpy as np
 import sys
 
-try:
-    # Try to import from the standard library first (Python >= 3.9)
+# Try to import from the standard library first (Python >= 3.9)
 if sys.version_info < (3, 9)
     from importlib import resources as importlib_resources
 else:

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -49,7 +49,7 @@ import numpy as np
 import sys
 
 # Try to import from the standard library first (Python >= 3.9)
-if sys.version_info < (3, 9)
+if sys.version_info < (3, 9):
     from importlib import resources as importlib_resources
 else:
     # Fall back to the backport

--- a/resampy/filters.py
+++ b/resampy/filters.py
@@ -46,8 +46,15 @@ where ``**kwargs`` are additional parameters to `sinc_window`.
 '''
 
 import numpy as np
-import importlib_resources
 import sys
+
+try:
+    # Try to import from the standard library first (Python >= 3.9)
+    from importlib import resources as importlib_resources
+except ImportError:
+    # Fall back to the backport
+    import importlib_resources
+
 
 FILTER_FUNCTIONS = ['sinc_window']
 FILTER_CACHE = dict()

--- a/resampy/version.py
+++ b/resampy/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '0.4'
-version = '0.4.2'
+version = '0.4.3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ python_requires >= 3.6
 install_requires =
     numpy>=1.17
     numba>=0.53
-    importlib_resources; python_verssion < "3.9"
+    importlib_resources; python_version < "3.9"
 
 [options.package_data]
 resampy = data/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,9 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+
 
 [options]
 packages = find:
@@ -40,7 +43,7 @@ python_requires >= 3.6
 install_requires =
     numpy>=1.17
     numba>=0.53
-    importlib_resources
+    importlib_resources; python_verssion < "3.9"
 
 [options.package_data]
 resampy = data/*
@@ -53,7 +56,7 @@ docs =
 tests =
     pytest < 8
     pytest-cov
-    scipy>=1.0
+    scipy>=1.11
 
 design =
     optuna >= 2.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ docs =
 tests =
     pytest < 8
     pytest-cov
-    scipy>=1.11
+    scipy>=1.1
 
 design =
     optuna >= 2.10.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -141,7 +141,7 @@ def test_good_window():
     sr_orig = 100
     sr_new = 200
     x = np.random.randn(500)
-    y = resampy.resample(x, sr_orig, sr_new, filter='sinc_window', window=scipy.signal.blackman)
+    y = resampy.resample(x, sr_orig, sr_new, filter='sinc_window', window=scipy.signal.windows.blackman)
 
     assert len(y) == 2 * len(x)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,7 +9,7 @@ import resampy
 
 
 @pytest.mark.parametrize('filt', ['sinc_window', resampy.filters.sinc_window])
-@pytest.mark.parametrize('window', [None, scipy.signal.hann])
+@pytest.mark.parametrize('window', [None, scipy.signal.windows.hann])
 @pytest.mark.parametrize('num_zeros', [None, 13])
 @pytest.mark.parametrize('precision', [None, 9])
 @pytest.mark.parametrize('rolloff', [None, 0.925])


### PR DESCRIPTION
This PR updates the tests for modern scipy, fixes some quirks in the CI environment specifications, and makes the dependence on `importlib_resources` only required for python < 3.9.