### PR TITLE
prefer newer unittest.mock

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,10 @@ master_doc = 'index'
 project = u'resampy'
 copyright = u'2016, Brian McFee'
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 MOCK_MODULES = ['numpy', 'scipy', 'scipy.signal', 'resampy.interp', 'numba']
 sys.modules.update((mod_name, mock.Mock()) for mod_name in MOCK_MODULES)
 


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock