### PR TITLE
Fix compatibility with Python >= 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         python -m pytest tests
         python -m pytest --doctest-only resampy
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,8 +66,10 @@ sys.modules.update((mod_name, mock.Mock()) for mod_name in MOCK_MODULES)
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-import imp
-resampy_version = imp.load_source('resampy.version', '../resampy/version.py')
+import importlib.util
+spec = importlib.util.spec_from_file_location('resampy.version', '../resampy/version.py')
+resampy_version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(resampy_version)
 
 # The short X.Y version.
 version = resampy_version.short_version


### PR DESCRIPTION
The `imp` module was deprecated long time ago and it has been removed in Python 3.12